### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "urls": [
+    ["ad9833.py", "github:KipCrossing/Micropython-AD9833/ad9833.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the module compatible with the MicroPython Package Manager (MIP).\n\nWith this change, users can install the module using: \\n\nThis PR is part of an effort to add package.json to popular MicroPython libraries.